### PR TITLE
added EMBL-GenBank-DDBJ_CDS database to uniprot_mapping_dbs.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Pycharm project settings
+.idea/

--- a/src/UniProtMapper/resources/uniprot_mapping_dbs.json
+++ b/src/UniProtMapper/resources/uniprot_mapping_dbs.json
@@ -13,6 +13,7 @@
     "Sequence databases": [
         "CCDS",
         "EMBL-GenBank-DDBJ",
+        "EMBL-GenBank-DDBJ_CDS",
         "GI_number",
         "PIR",
         "RefSeq_Nucleotide",


### PR DESCRIPTION
UniProt has support for mapping from protein accession numbers to UniProtKB ids (see example [here](https://www.uniprot.org/id-mapping/uniprotkb/a5194a36bf078cae3043d9014fa764da02c7c3fb/input-parameters)). I have added the 'from' database name as shown in that example request ("EMBL-GenBank-DDBJ_CDS") to `uniprot_mapping_dbs.json`. I tested the change by installing from source locally and it works. 